### PR TITLE
Potential fix for code scanning alert no. 38: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/haclabs/hacCare/security/code-scanning/38](https://github.com/haclabs/hacCare/security/code-scanning/38)

To fix the problem, we should add a `permissions` block to the workflow file `.github/workflows/ci.yml`. The best approach is to add this block near the workflow’s top level (just below `name: CI`), which will apply the restriction to all jobs unless overridden. Based on the provided steps, all jobs only require read-only access to the repository contents, so we set `contents: read` as the minimal permissions. If in the future a job requires additional access (e.g., to create pull requests or modify issues), individual jobs can override this block, but for now, least privilege is preferred. The block to add is:

```yaml
permissions:
  contents: read
```

This should be added between line 1 (`name: CI`) and line 3 (`on:`). No new imports, methods, functions, or definitions are required—just this YAML config addition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
