### PR TITLE
Potential fix for code scanning alert no. 29: Clear text storage of sensitive information

### DIFF
--- a/src/contexts/auth/AuthContext.tsx
+++ b/src/contexts/auth/AuthContext.tsx
@@ -628,8 +628,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
           } else {
             const errorText = await response.text();
             console.error('❌ Direct fetch failed:', response.status, errorText);
-            // See security note above - storing access token for direct API calls
-            sessionStorage.setItem('supabase_access_token', data.session.access_token);
+            // Store a non-sensitive flag to indicate profile is missing, without persisting the access token
+            sessionStorage.setItem('supabase_profile_status', 'missing');
             setUser(data.session.user);
             setProfile(null);
             setLoading(false);
@@ -637,8 +637,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         } catch (fetchError) {
           console.error('💥 Exception during direct fetch:', fetchError);
           // Set user anyway so they can create profile
-          // See security note above - storing access token for direct API calls
-          sessionStorage.setItem('supabase_access_token', data.session.access_token);
+          // Store a non-sensitive flag to indicate profile is missing, without persisting the access token
+          sessionStorage.setItem('supabase_profile_status', 'missing');
           setUser(data.session.user);
           setProfile(null);
           setLoading(false);


### PR DESCRIPTION
Potential fix for [https://github.com/haclabs/hacCare/security/code-scanning/29](https://github.com/haclabs/hacCare/security/code-scanning/29)

General approach: avoid storing the raw `access_token` in browser storage. Instead, rely on Supabase’s built‑in session management and, if needed, store only non-sensitive indicators (e.g., “profile missing, show onboarding”) or opaque IDs that the backend can map to sensitive data. If the application truly needs a token outside the Supabase client, consider a short‑lived, backend‑generated token stored in memory only, not in persistent storage.

Best fix for this snippet without changing app behavior more than necessary:

- Remove the two calls to `sessionStorage.setItem('supabase_access_token', data.session.access_token);` at:
  - Line 632 (inside the `else` when direct profile fetch fails but auth succeeded).
  - Line 641 (inside the `catch (fetchError)` block).
- If some downstream code expects `sessionStorage.supabase_access_token` to exist, we must replace the value with a non-sensitive placeholder that does not allow authentication. However, since we cannot see other files, the safest change within this file is to eliminate the sensitive storage and, if necessary, replace it with a benign flag like `sessionStorage.setItem('supabase_profile_status', 'missing')`. This preserves the logic that “user is signed in but profile is missing” without leaking credentials.
- We do not need new imports or external libraries; we only modify the two `sessionStorage.setItem` lines and can optionally add a short inline comment explaining the change.

Concretely:

- In `src/contexts/auth/AuthContext.tsx`, around lines 628–636, replace:
  - `sessionStorage.setItem('supabase_access_token', data.session.access_token);`
  with a non-sensitive flag or remove it.
- In the `catch (fetchError)` block around lines 637–644, do the same.

I’ll opt for replacing the token storage with a boolean/flag that conveys the same control-flow information (profile not yet loaded) but no sensitive data:

- Replace both with: `sessionStorage.setItem('supabase_profile_status', 'missing');`

This preserves the idea that the app might depend on some `sessionStorage` state while eliminating clear-text sensitive storage.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
