### PR TITLE
fix: resolve CodeQL #26-29 clear-text token storage in sessionStorage

### DIFF
--- a/src/contexts/auth/AuthContext.tsx
+++ b/src/contexts/auth/AuthContext.tsx
@@ -585,28 +585,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
               secureLogger.debug('✅ Profile found:', profiles[0]);
               secureLogger.debug('👤 Profile role:', profiles[0].role, 'Is super_admin?', profiles[0].role === 'super_admin');
               
-              /**
-               * SECURITY NOTE: Storing access token in sessionStorage
-               * 
-               * This is a temporary workaround for Supabase client hanging issues.
-               * The access token stored here is:
-               * - Short-lived (expires in 1 hour by default)
-               * - sessionStorage only (cleared on tab close, not persistent)
-               * - Used only for direct API calls that bypass hanging Supabase client
-               * - NOT a refresh token (those are httpOnly cookies managed by Supabase)
-               * 
-               * Security considerations:
-               * - XSS Risk: Mitigated by CSP headers and input sanitization
-               * - Session hijacking: Limited by short expiry and session-only storage
-               * - CSRF: Not applicable for API calls (requires auth token)
-               * 
-               * TODO: Remove this once Supabase client hanging issues are resolved
-               * Alternative: Use Supabase's built-in session management exclusively
-               * 
-               * CodeQL Alert: Acknowledged - this is intentional for specific API calls
-               */
-              sessionStorage.setItem('supabase_access_token', data.session.access_token);
-              
               // Use React 18's automatic batching - all state updates in same function are batched
               setUser(data.session.user);
               setProfile(profiles[0]);
@@ -620,8 +598,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
               secureLogger.debug('🏁 User and profile state updated');
             } else {
               secureLogger.warn('⚠️ No profile found for user');
-              // See security note above - storing access token for direct API calls
-              sessionStorage.setItem('supabase_access_token', data.session.access_token);
               setUser(data.session.user);
               setProfile(null);
               setLoading(false);
@@ -629,8 +605,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
           } else {
             const errorText = await response.text();
             secureLogger.error('❌ Direct fetch failed:', response.status, errorText);
-            // See security note above - storing access token for direct API calls
-            sessionStorage.setItem('supabase_access_token', data.session.access_token);
             setUser(data.session.user);
             setProfile(null);
             setLoading(false);
@@ -638,8 +612,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         } catch (fetchError) {
           secureLogger.error('💥 Exception during direct fetch:', fetchError);
           // Set user anyway so they can create profile
-          // See security note above - storing access token for direct API calls
-          sessionStorage.setItem('supabase_access_token', data.session.access_token);
           setUser(data.session.user);
           setProfile(null);
           setLoading(false);
@@ -703,15 +675,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
             secureLogger.debug('🗑️ Removed localStorage key:', key);
           }
         }
-        
-        // Clear the stored access token used for direct fetches
-        sessionStorage.removeItem('supabase_access_token');
-        secureLogger.debug('🗑️ Removed stored access token');
-      
       } catch (error) {
         secureLogger.error('❌ Error clearing localStorage:', error);
       }
-      
+
       setUser(null);
       setProfile(null);
     }

--- a/src/services/admin/tenantService.ts
+++ b/src/services/admin/tenantService.ts
@@ -558,9 +558,10 @@ export async function getCurrentUserTenant(userId: string): Promise<{ data: Tena
   try {
     secureLogger.debug('🔍 getCurrentUserTenant: Starting for user:', userId);
     
-    // Try to get access token from sessionStorage (set during login to bypass hanging Supabase client)
-    const accessToken = sessionStorage.getItem('supabase_access_token');
-    
+    // Get access token from Supabase's own session (in-memory / secure storage, no sessionStorage needed)
+    const { data: sessionData } = await supabase.auth.getSession();
+    const accessToken = sessionData?.session?.access_token ?? null;
+
     if (accessToken) {
       secureLogger.debug('🔑 Using direct HTTP fetch with stored access token');
       


### PR DESCRIPTION
## Summary

Resolves CodeQL security alerts **#26, #27, #28, #29** — "Clear text storage of sensitive information" in `AuthContext.tsx`.

## Root Cause

`signIn()` was storing the raw Supabase access token in `sessionStorage` as a workaround for a Supabase client hanging issue. `tenantService.getCurrentUserTenant()` then read it back for direct HTTP calls.

## Fix

- **`AuthContext.tsx`**: Removed all 4 `sessionStorage.setItem('supabase_access_token', ...)` calls and the corresponding `removeItem` on sign out
- **`tenantService.ts`**: Replaced `sessionStorage.getItem('supabase_access_token')` with `(await supabase.auth.getSession()).data.session?.access_token`

`supabase.auth.getSession()` reads from Supabase's own secure storage (`sb-*` localStorage keys) without any network call, so there's no hanging risk and no need to cache the token separately.

## Risk

Low — the direct HTTP fallback path in `tenantService` still works identically, just gets its token from `getSession()` instead of sessionStorage.