### PR TITLE
fix: instructor simulation completion records no student work (RLS)

### DIFF
--- a/database/migrations/20260417000000_fix_instructor_simulation_completion_access.sql
+++ b/database/migrations/20260417000000_fix_instructor_simulation_completion_access.sql
@@ -1,12 +1,26 @@
 -- ============================================================================
--- LAUNCH SIMULATION FUNCTION WITH CATEGORIES
+-- FIX: INSTRUCTOR SIMULATION COMPLETION ACCESS
 -- ============================================================================
--- Enhanced version that accepts category tags for better organization
+-- Bug: When an instructor (non-super_admin) completes a simulation, the debrief
+-- captures zero student work. Super admins work correctly.
+--
+-- Root cause: launch_simulation_with_categories only adds *participants* to
+-- tenant_users for the simulation's active tenant — the instructor who launches
+-- and will complete the simulation is never added. When getStudentActivitiesBySimulation
+-- queries clinical tables (patient_vitals, medication_administrations, etc.),
+-- the tenant_users-based RLS policies return empty result sets for instructors.
+-- Super admins bypass RLS entirely, hence they see the full debrief.
+--
+-- Fix applied:
+--   1. Redeploy launch_simulation (via CREATE OR REPLACE) to also add the
+--      launching user (auth.uid()) to tenant_users as 'admin' on launch.
+--      This covers all future simulation launches.
+--
+--   2. The TypeScript handleCompleteWithInstructor (useActiveSimulations.ts)
+--      has been updated to upsert the completing user into tenant_users before
+--      querying activities — this covers already-running simulations that were
+--      launched without the fix.
 -- ============================================================================
-
--- Drop existing function
-DROP FUNCTION IF EXISTS launch_simulation(UUID, TEXT, INTEGER, UUID[], TEXT[]);
-DROP FUNCTION IF EXISTS launch_simulation(UUID, TEXT, INTEGER, UUID[], TEXT[], TEXT[], TEXT[]);
 
 CREATE OR REPLACE FUNCTION launch_simulation(
   p_template_id UUID,
@@ -131,7 +145,7 @@ BEGIN
     auth.uid(),
     'running',
     v_template_snapshot_version,
-    v_template_snapshot_version,  -- Launched at current template version
+    v_template_snapshot_version,
     p_primary_categories,
     p_sub_categories
   );
@@ -141,10 +155,12 @@ BEGIN
     array_to_string(p_primary_categories, ', '), 
     array_to_string(p_sub_categories, ', ');
 
-  -- Add the launching instructor to tenant_users so they can read all clinical
-  -- tables when generating the debrief on completion.  Previously only
-  -- participants were added here; the launcher was omitted, causing RLS to block
-  -- getStudentActivitiesBySimulation for non-super_admin instructors.
+  -- =========================================================================
+  -- FIX: Add the launching instructor to tenant_users so they can read all
+  -- clinical tables when generating the debrief on completion.
+  -- Previously only participants were added here; the launcher was omitted,
+  -- causing RLS to block getStudentActivitiesBySimulation for non-super_admins.
+  -- =========================================================================
   INSERT INTO tenant_users (user_id, tenant_id, is_active, role)
   VALUES (auth.uid(), v_simulation_tenant_id, true, 'admin')
   ON CONFLICT (user_id, tenant_id) DO UPDATE
@@ -197,4 +213,4 @@ BEGIN
 END;
 $$;
 
-COMMENT ON FUNCTION launch_simulation IS 'Launch simulation with category tags for organization and filtering';
+COMMENT ON FUNCTION launch_simulation IS 'Launch simulation with category tags for organization and filtering. Instructor (launcher) is explicitly added to tenant_users for debrief RLS access.';

--- a/src/features/simulation/components/ActiveSimulations.tsx
+++ b/src/features/simulation/components/ActiveSimulations.tsx
@@ -222,11 +222,35 @@ const ActiveSimulations: React.FC = () => {
     if (!completingSimulation) return;
     
     const id = completingSimulation.id;
+    const simTenantId = completingSimulation.tenant_id;
     secureLogger.debug('🎯 handleComplete called for:', id, 'Instructor:', instructorName);
     setActionLoading(id);
     setCompletingSimulation(null);
     
     try {
+      // Ensure this user has RLS read access to the simulation's tenant so that
+      // getStudentActivitiesBySimulation can query clinical tables.  Instructors
+      // are not added to tenant_users at launch time (only participants are), so
+      // without this upsert all clinical queries return empty arrays for non-super_admin users.
+      const { data: { user } } = await supabase.auth.getUser();
+      if (user && simTenantId) {
+        const { error: accessError } = await supabase
+          .from('tenant_users')
+          .upsert({
+            user_id: user.id,
+            tenant_id: simTenantId,
+            is_active: true,
+            role: 'admin'
+          }, { onConflict: 'user_id,tenant_id' });
+
+        if (accessError) {
+          secureLogger.warn('⚠️ Could not grant simulation tenant access:', accessError);
+          // Continue anyway — super_admin bypasses RLS regardless
+        } else {
+          secureLogger.debug('✅ Instructor granted read access to simulation tenant for debrief');
+        }
+      }
+
       // First, get student activities BEFORE completing
       secureLogger.debug('📊 Generating student activity report...');
       const { getStudentActivitiesBySimulation } = await import('../../../services/simulation/studentActivityService');


### PR DESCRIPTION
## Bug
When an instructor (non-super_admin) completes a simulation, the debrief records **zero student work**. Super admins completing the same simulation see everything correctly.

## Root Cause
`launch_simulation_with_categories` adds **participants** to `tenant_users` for the simulation's active tenant — but never the instructor who launches it. Every clinical table RLS policy gates reads on `tenant_users` membership. Super admins bypass RLS entirely; instructors are silently blocked, so `getStudentActivitiesBySimulation` returns empty arrays.

## Fix

### 1. `ActiveSimulations.tsx` (immediate — covers already-running simulations)
Before calling `getStudentActivitiesBySimulation`, upsert the completing instructor into `tenant_users` for the simulation's tenant. Mirrors the exact same pattern already used by `enterTemplateTenant` for template editing.

### 2. `launch_simulation_with_categories.sql` + migration `20260417000000`
Add `auth.uid()` to `tenant_users` as `admin` when creating the simulation tenant at launch time, so the instructor has access from the start. Also cleans up the participant loop to use `ON CONFLICT DO UPDATE` instead of the old exception-handler pattern.

## Testing
- Run the backfill SQL in Supabase for any currently-running simulations:
```sql
INSERT INTO tenant_users (user_id, tenant_id, is_active, role)
SELECT sa.created_by, sa.tenant_id, true, 'admin'
FROM simulation_active sa
WHERE sa.status IN ('running', 'paused') AND sa.created_by IS NOT NULL
ON CONFLICT (user_id, tenant_id) DO UPDATE SET is_active = true, role = 'admin';
```
- Complete a simulation as an instructor — debrief should now show all student entries
- Run migration `20260417000000` to deploy the fixed launch function