### PR TITLE
hotfix: restore correct MFA implementation after bad conflict resolution

### DIFF
--- a/src/components/Auth/LoginForm.tsx
+++ b/src/components/Auth/LoginForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Eye, EyeOff, AlertCircle, Shield } from 'lucide-react';
 import { useAuth } from '../../hooks/useAuth';
 import { parseAuthError } from '../../utils/authErrorParser';
@@ -6,6 +6,17 @@ import { isSupabaseConfigured, supabase } from '../../lib/api/supabase';
 import logo from '../../images/logo.png';
 import { secureLogger } from '../../lib/security/secureLogger';
 import { PrivacyNoticeModal } from './PrivacyNoticeModal';
+import { MFAChallenge } from './MFAChallenge';
+import { MFAEnrollment } from './MFAEnrollment';
+
+const doRedirect = (simulationOnly?: boolean) => {
+  if (simulationOnly) {
+    localStorage.removeItem('current_simulation_tenant');
+    window.location.href = '/app/simulation-portal';
+  } else {
+    window.location.href = '/app';
+  }
+};
 
 export const LoginForm: React.FC = () => {
   const [email, setEmail] = useState('');
@@ -15,71 +26,26 @@ export const LoginForm: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [oauthLoading, setOauthLoading] = useState(false);
   const [showPrivacyNotice, setShowPrivacyNotice] = useState(false);
-  const { signIn, user, profile } = useAuth();
+  const [mfaMode, setMfaMode] = useState<'challenge' | 'enroll' | null>(null);
+  const { signIn, signOut, user, profile } = useAuth();
 
-  const doRedirect = () => {
-    if (profile?.simulation_only) {
-      secureLogger.debug('🎯 Simulation-only user detected, redirecting to lobby...');
-      localStorage.removeItem('current_simulation_tenant');
-      setTimeout(() => {
-        window.location.href = '/app/simulation-portal';
-      }, 100);
-    } else {
-      secureLogger.debug('🎯 Regular user detected, redirecting to app...');
-      setTimeout(() => {
-        window.location.href = '/app';
-      }, 100);
-    }
-  };
-
-  // Redirect based on user type after login, with MFA gate for super_admin
+  // For non-super_admin users the redirect is handled inline in handleSubmit.
+  // This effect is a fallback for OAuth / session-restored users where
+  // handleSubmit was never called (e.g. INITIAL_SESSION on page load).
   useEffect(() => {
     if (!user || !profile) return;
-    if (mfaChecked.current) return;
-    mfaChecked.current = true;
-
-    if (profile.role !== 'super_admin') {
-      doRedirect();
-      return;
-    }
-
-    // Super admin: check MFA assurance level before allowing redirect
-    const checkMFA = async () => {
-      try {
-        const { data, error: aalError } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
-        if (aalError) throw aalError;
-
-        if (data.currentLevel === 'aal2') {
-          // Already fully verified (e.g., session restored)
-          secureLogger.debug('✅ Super admin already at AAL2, proceeding');
-          doRedirect();
-        } else if (data.nextLevel === 'aal2') {
-          // Has enrolled factors but hasn't verified this session
-          secureLogger.debug('🔐 Super admin has MFA enrolled — showing challenge');
-          setMfaMode('challenge');
-        } else {
-          // No factors enrolled yet — force enrollment
-          secureLogger.debug('🔐 Super admin has no MFA factors — showing enrollment');
-          setMfaMode('enroll');
-        }
-      } catch (err: any) {
-        secureLogger.error('MFA AAL check failed, allowing login:', err);
-        // Fail open rather than locking out the admin
-        doRedirect();
-      }
-    };
-
-    checkMFA();
-  }, [user, profile]); // eslint-disable-line react-hooks/exhaustive-deps
+    if (profile.role === 'super_admin') return; // handled in handleSubmit
+    if (mfaMode !== null) return; // MFA modal is open, don't redirect yet
+    doRedirect(profile.simulation_only);
+  }, [user?.id, profile?.role]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleMFASuccess = () => {
     setMfaMode(null);
-    doRedirect();
+    window.location.href = '/app';
   };
 
   const handleMFACancel = async () => {
     setMfaMode(null);
-    mfaChecked.current = false;
     await signOut();
   };
 
@@ -318,6 +284,14 @@ export const LoginForm: React.FC = () => {
 
       {showPrivacyNotice && (
         <PrivacyNoticeModal onClose={() => setShowPrivacyNotice(false)} />
+      )}
+
+      {mfaMode === 'challenge' && (
+        <MFAChallenge onSuccess={handleMFASuccess} onCancel={handleMFACancel} />
+      )}
+
+      {mfaMode === 'enroll' && (
+        <MFAEnrollment onSuccess={handleMFASuccess} onCancel={handleMFACancel} />
       )}
     </div>
   );

--- a/src/components/Auth/MFAChallenge.tsx
+++ b/src/components/Auth/MFAChallenge.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Shield, AlertCircle } from 'lucide-react';
 import { supabase } from '../../lib/api/supabase';
 import { secureLogger } from '../../lib/security/secureLogger';
@@ -15,8 +15,14 @@ export const MFAChallenge: React.FC<MFAChallengeProps> = ({ onSuccess, onCancel 
   const [factorId, setFactorId] = useState<string | null>(null);
   const [challengeId, setChallengeId] = useState<string | null>(null);
   const [initialising, setInitialising] = useState(true);
+  // Guard against React StrictMode double-invoking the effect (would create two
+  // challenges for the same factor; only the last one is valid causing verify to fail).
+  const hasStartedRef = useRef(false);
 
   useEffect(() => {
+    if (hasStartedRef.current) return;
+    hasStartedRef.current = true;
+
     const initChallenge = async () => {
       try {
         const { data: factors, error: listError } = await supabase.auth.mfa.listFactors();

--- a/src/components/Auth/MFAEnrollment.tsx
+++ b/src/components/Auth/MFAEnrollment.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Shield, AlertCircle } from 'lucide-react';
 import { supabase } from '../../lib/api/supabase';
 import { secureLogger } from '../../lib/security/secureLogger';
@@ -16,18 +16,21 @@ export const MFAEnrollment: React.FC<MFAEnrollmentProps> = ({ onSuccess, onCance
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const [initialising, setInitialising] = useState(true);
+  // Guard against React StrictMode double-invoking the effect, which would create
+  // two enroll() calls back-to-back and trigger mfa_factor_name_conflict on the second.
+  const hasStartedRef = useRef(false);
 
   useEffect(() => {
+    if (hasStartedRef.current) return;
+    hasStartedRef.current = true;
+
     const startEnrollment = async () => {
       try {
-        const { data, error: enrollError } = await supabase.auth.mfa.enroll({
-          factorType: 'totp',
-        });
-        if (enrollError) throw enrollError;
+        let enrollData = await attemptEnroll();
 
-        setFactorId(data.id);
-        setQrCode(data.totp.qr_code);
-        setSecret(data.totp.secret);
+        setFactorId(enrollData.id);
+        setQrCode(enrollData.totp.qr_code);
+        setSecret(enrollData.totp.secret);
       } catch (err: any) {
         secureLogger.error('MFA enroll init failed:', err);
         setError(err.message ?? 'Failed to start MFA enrollment. Please try again.');
@@ -38,6 +41,39 @@ export const MFAEnrollment: React.FC<MFAEnrollmentProps> = ({ onSuccess, onCance
 
     startEnrollment();
   }, []);
+
+  /**
+   * Attempts to enroll a new TOTP factor.
+   * If a stale unverified factor already exists (mfa_factor_name_conflict), it is
+   * unenrolled first and then enrollment is retried once.
+   */
+  const attemptEnroll = async () => {
+    const { data, error: enrollError } = await supabase.auth.mfa.enroll({
+      factorType: 'totp',
+    });
+
+    if (!enrollError) return data;
+
+    if (enrollError.code === 'mfa_factor_name_conflict') {
+      secureLogger.warn('Stale unverified MFA factor detected — unenrolling and retrying...');
+
+      // Find and remove the conflicting unverified factor
+      const { data: factors } = await supabase.auth.mfa.listFactors();
+      const stale = factors?.totp?.find((f) => f.status === 'unverified');
+      if (stale) {
+        await supabase.auth.mfa.unenroll({ factorId: stale.id });
+      }
+
+      // Retry enrollment with a clean slate
+      const { data: retryData, error: retryError } = await supabase.auth.mfa.enroll({
+        factorType: 'totp',
+      });
+      if (retryError) throw retryError;
+      return retryData;
+    }
+
+    throw enrollError;
+  };
 
   const handleVerify = async (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## What happened

PRs #280 and #281 both targeted `refactor/lint-cleanup-phase1 → main`. When merging #281, the conflict resolution mixed the old `useEffect`/`mfaChecked` approach (from #280) with the new `handleSubmit` approach (from #281). Result: `mfaChecked`, `mfaMode`, and `signOut` were all referenced but never declared — causing a `ReferenceError` in production.

## What this fixes

Restores the 4 correct files directly from the `refactor/lint-cleanup-phase1` branch (the fully tested version):

- `LoginForm.tsx` — MFA check in `handleSubmit`, no `mfaChecked` ref, correct state declarations
- `MFAChallenge.tsx` — StrictMode guard via `hasStartedRef`
- `MFAEnrollment.tsx` — StrictMode guard + stale factor auto-cleanup
- `AuthContext.tsx` — `signIn()` returns `profile` alongside `error`

## This PR has no conflicts — merge without touching conflict resolution.