### PR TITLE
fix: prevent MFA hang on re-login (_useSession race condition)

### DIFF
--- a/src/components/Auth/LoginForm.tsx
+++ b/src/components/Auth/LoginForm.tsx
@@ -27,15 +27,26 @@ export const LoginForm: React.FC = () => {
   const [oauthLoading, setOauthLoading] = useState(false);
   const [showPrivacyNotice, setShowPrivacyNotice] = useState(false);
   const [mfaMode, setMfaMode] = useState<'challenge' | 'enroll' | null>(null);
+  // Tracks whether a form submit is in progress. Prevents the useEffect below
+  // from firing checkRestoredSession() concurrently with handleSubmit's own AAL
+  // check — two simultaneous getAuthenticatorAssuranceLevel() calls contend on
+  // Supabase's internal _useSession lock and cause an indefinite hang.
+  const submitActiveRef = React.useRef(false);
   const { signIn, signOut, user, profile } = useAuth();
 
   // Redirect effect — covers two cases:
-  // 1. Non-super_admin: redirect immediately once user+profile are available.
+  // 1. Non-super_admin: redirect immediately once user+profile are available
+  //    (OAuth sign-in or restored session — handleSubmit handles the direct path).
   // 2. Super_admin with a RESTORED session (page reload / INITIAL_SESSION):
   //    handleSubmit won't have been called, so we still need to gate on MFA here.
+  //
+  // IMPORTANT: submitActiveRef guards against this effect firing while handleSubmit
+  // is already executing the AAL check — that would create two concurrent
+  // getAuthenticatorAssuranceLevel() calls and hang due to _useSession lock.
   useEffect(() => {
     if (!user || !profile) return;
-    if (mfaMode !== null) return; // MFA modal is open, don't redirect yet
+    if (mfaMode !== null) return; // MFA modal already open
+    if (submitActiveRef.current) return; // handleSubmit is driving the MFA flow
 
     if (profile.role !== 'super_admin') {
       doRedirect(profile.simulation_only);
@@ -43,8 +54,6 @@ export const LoginForm: React.FC = () => {
     }
 
     // Super admin with a restored session — check AAL level now.
-    // (When coming through handleSubmit this codepath is skipped because
-    //  mfaMode will already be set before the profile state settles.)
     const checkRestoredSession = async () => {
       try {
         const { data: aal, error: aalError } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
@@ -86,6 +95,10 @@ export const LoginForm: React.FC = () => {
       setError('Database connection not configured. Please set up Supabase.');
       return;
     }
+
+    // Mark a form submit as active so the useEffect above won't fire
+    // checkRestoredSession() concurrently with our own AAL check below.
+    submitActiveRef.current = true;
 
     setError('');
     setLoading(true);

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -385,6 +385,13 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       // Fetch the profile immediately so the caller can make role-based decisions
       // (e.g. whether to show MFA challenge) without waiting for the async
       // onAuthStateChange → fetchUserProfile cycle to complete.
+      // NOTE: We intentionally do NOT call setProfile() here. Storing the profile
+      // in context at this point would trigger LoginForm's useEffect (which depends
+      // on profile?.role) while handleSubmit is still mid-execution awaiting the AAL
+      // check. That creates two concurrent getAuthenticatorAssuranceLevel() calls
+      // which contend on Supabase's internal _useSession lock and cause a hang.
+      // The onAuthStateChange → fetchUserProfile pipeline sets profile in context
+      // after the form-submit MFA flow is already in motion.
       let signedInProfile: UserProfile | null = null;
       if (signInData?.user) {
         try {
@@ -394,8 +401,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
             .eq('id', signInData.user.id)
             .single();
           signedInProfile = profileData ?? null;
-          // Sync into context state so the rest of the app sees it immediately
-          if (mounted.current) setProfile(signedInProfile);
         } catch (profileErr) {
           secureLogger.error('Profile fetch after sign in failed:', profileErr);
         }


### PR DESCRIPTION
## Problem

After logout → re-login, MFA was hanging indefinitely without clearing site data.

## Root Cause

`signIn()` in `AuthContext` called `setProfile()` immediately after fetching the user profile. This caused `LoginForm`'s `useEffect` (which watches `profile?.role`) to fire `checkRestoredSession()` **while `handleSubmit` was still mid-execution** awaiting its own `getAuthenticatorAssuranceLevel()` call.

Result: two concurrent calls to `getAuthenticatorAssuranceLevel()` contending on Supabase's internal `_useSession` mutex → indefinite hang.

## Fix

**`src/contexts/AuthContext.tsx`**
- Removed `setProfile()` from `signIn()`. Profile is fetched and returned to the caller but **not** stored in context state during the form submit. The `onAuthStateChange → fetchUserProfile` pipeline updates context after the MFA flow is already in motion.

**`src/components/Auth/LoginForm.tsx`**
- Added `submitActiveRef` (`React.useRef(false)`), set to `true` at the start of `handleSubmit`.
- The `useEffect` checks `submitActiveRef.current` as a hard guard — `checkRestoredSession()` never runs concurrently with `handleSubmit`'s own AAL check.

## Testing

- Fresh login as super_admin → MFA challenge ✅
- Logout → login again → MFA challenge (no hang) ✅
- Page reload with existing session → MFA challenge ✅
- Non-super_admin login → direct redirect, no MFA ✅