### PR TITLE
fix(ci): use Supabase CLI + pooler to avoid IPv6 connectivity issues in GitHub Actions

### DIFF
--- a/.github/workflows/migrate-to-canada.yml
+++ b/.github/workflows/migrate-to-canada.yml
@@ -2,15 +2,18 @@
 # Trigger manually from GitHub Actions tab → "Run workflow"
 # DELETE THIS FILE after migration is complete.
 #
-# Required GitHub Secrets:
-#   OLD_DB_URL      = postgresql://postgres:[password]@db.cwhqffubvqolhnkecyck.supabase.co:5432/postgres
-#   OLD_DB_PASSWORD = old project DB password
-#   NEW_DB_URL      = postgresql://postgres:[password]@db.[canada-ref].supabase.co:5432/postgres
-#   NEW_DB_PASSWORD = new Canada project DB password
+# Uses Supabase CLI for dumping (HTTPS/443 — avoids IPv6 direct DB connection issues).
+# Uses connection pooler URLs for restore (IPv4 compatible).
 #
-# NOTE: Only the public schema is migrated here. Auth users live in the auth schema,
-# which Supabase manages internally. To migrate users, use the Supabase Dashboard
-# "Move project" feature or migrate auth.users rows separately after this runs.
+# Required GitHub Secrets:
+#   SUPABASE_ACCESS_TOKEN = Personal access token from supabase.com/dashboard/account/tokens
+#   OLD_DB_REF            = cwhqffubvqolhnkecyck  (just the project ref, no URL)
+#   OLD_DB_PASSWORD       = old project DB password
+#   NEW_DB_REF            = your Canada project ref (e.g. abcdefghijklmnop)
+#   NEW_DB_PASSWORD       = new Canada project DB password
+#
+# Pooler URLs (IPv4) are built automatically from the ref + password above.
+# Find your pooler host in: Supabase Dashboard → Settings → Database → Connection Pooling
 
 name: Migrate Supabase US → Canada
 
@@ -28,78 +31,68 @@ jobs:
 
     steps:
       - name: Checkout repo (for migration SQL files)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - name: Install PostgreSQL client
+      - name: Install Supabase CLI + PostgreSQL client
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y postgresql-client
+          npm install -g supabase@latest
 
-      - name: Dump public schema from US East project
+      - name: Dump public schema via Supabase CLI (HTTPS — no IPv6 issues)
         env:
-          PGPASSWORD: ${{ secrets.OLD_DB_PASSWORD }}
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
         run: |
-          pg_dump \
-            --format=custom \
-            --no-acl \
-            --no-owner \
-            --no-tablespaces \
-            --schema=public \
-            --file=haccare_migration.dump \
-            "${{ secrets.OLD_DB_URL }}"
-          echo "Dump size: $(du -sh haccare_migration.dump | cut -f1)"
+          supabase db dump \
+            --project-ref "${{ secrets.OLD_DB_REF }}" \
+            --schema public \
+            --file haccare_public.sql
+          echo "Public dump size: $(du -sh haccare_public.sql | cut -f1)"
 
-      - name: Dump auth users (data only) from US East project
+      - name: Dump auth users via Supabase CLI (data only)
         env:
-          PGPASSWORD: ${{ secrets.OLD_DB_PASSWORD }}
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
         run: |
-          pg_dump \
-            --format=plain \
+          supabase db dump \
+            --project-ref "${{ secrets.OLD_DB_REF }}" \
+            --schema auth \
             --data-only \
-            --no-acl \
-            --no-owner \
-            --schema=auth \
-            --table=auth.users \
-            --table=auth.identities \
-            --file=haccare_auth.sql \
-            "${{ secrets.OLD_DB_URL }}"
+            --file haccare_auth.sql
           echo "Auth dump size: $(du -sh haccare_auth.sql | cut -f1)"
 
-      - name: Restore public schema to Canada project
+      - name: Restore public schema to Canada project (via pooler — IPv4)
         env:
           PGPASSWORD: ${{ secrets.NEW_DB_PASSWORD }}
+          # Pooler URL format: postgresql://postgres.[ref]:[password]@aws-0-ca-central-1.pooler.supabase.com:5432/postgres
+          NEW_POOLER_URL: postgresql://postgres.${{ secrets.NEW_DB_REF }}:${{ secrets.NEW_DB_PASSWORD }}@aws-0-ca-central-1.pooler.supabase.com:5432/postgres
         run: |
-          pg_restore \
-            --verbose \
-            --no-acl \
-            --no-owner \
-            --no-tablespaces \
-            --dbname="${{ secrets.NEW_DB_URL }}" \
-            haccare_migration.dump
+          psql "$NEW_POOLER_URL" --file=haccare_public.sql
           echo "Public schema restore complete"
 
       - name: Restore auth users to Canada project
         env:
           PGPASSWORD: ${{ secrets.NEW_DB_PASSWORD }}
+          NEW_POOLER_URL: postgresql://postgres.${{ secrets.NEW_DB_REF }}:${{ secrets.NEW_DB_PASSWORD }}@aws-0-ca-central-1.pooler.supabase.com:5432/postgres
         run: |
-          # Truncate first to avoid duplicate key violations
-          psql "${{ secrets.NEW_DB_URL }}" -c "TRUNCATE auth.identities CASCADE; TRUNCATE auth.users CASCADE;"
-          psql "${{ secrets.NEW_DB_URL }}" --file=haccare_auth.sql
+          psql "$NEW_POOLER_URL" -c "TRUNCATE auth.identities CASCADE; TRUNCATE auth.users CASCADE;"
+          psql "$NEW_POOLER_URL" --file=haccare_auth.sql
           echo "Auth user restore complete"
 
       - name: Apply RLS event trigger migration
         env:
           PGPASSWORD: ${{ secrets.NEW_DB_PASSWORD }}
+          NEW_POOLER_URL: postgresql://postgres.${{ secrets.NEW_DB_REF }}:${{ secrets.NEW_DB_PASSWORD }}@aws-0-ca-central-1.pooler.supabase.com:5432/postgres
         run: |
-          psql "${{ secrets.NEW_DB_URL }}" \
+          psql "$NEW_POOLER_URL" \
             --file=database/migrations/20260507000000_enable_automatic_rls_event_trigger.sql
           echo "RLS event trigger applied"
 
       - name: Verify row counts
         env:
           PGPASSWORD: ${{ secrets.NEW_DB_PASSWORD }}
+          NEW_POOLER_URL: postgresql://postgres.${{ secrets.NEW_DB_REF }}:${{ secrets.NEW_DB_PASSWORD }}@aws-0-ca-central-1.pooler.supabase.com:5432/postgres
         run: |
-          psql "${{ secrets.NEW_DB_URL }}" <<'SQL'
+          psql "$NEW_POOLER_URL" <<'SQL'
             SELECT table_name,
                    (xpath('/row/c/text()', query_to_xml('SELECT COUNT(*) AS c FROM public.' || quote_ident(table_name), false, true, '')))[1]::text::int AS row_count
             FROM information_schema.tables
@@ -111,5 +104,6 @@ jobs:
       - name: Verify auth users migrated
         env:
           PGPASSWORD: ${{ secrets.NEW_DB_PASSWORD }}
+          NEW_POOLER_URL: postgresql://postgres.${{ secrets.NEW_DB_REF }}:${{ secrets.NEW_DB_PASSWORD }}@aws-0-ca-central-1.pooler.supabase.com:5432/postgres
         run: |
-          psql "${{ secrets.NEW_DB_URL }}" -c "SELECT COUNT(*) AS user_count FROM auth.users;"
+          psql "$NEW_POOLER_URL" -c "SELECT COUNT(*) AS user_count FROM auth.users;"


### PR DESCRIPTION
## Problem

The `migrate-to-canada.yml` workflow was failing in GitHub Actions because direct PostgreSQL connections to Supabase use IPv6, which GitHub-hosted runners don't support.

## Fix

- **Dump**: Switched from `pg_dump` (direct DB connection) to `supabase db dump` via the Supabase CLI, which uses HTTPS (port 443) — no IPv6 required
- **Restore**: Switched from direct DB URLs to the **connection pooler** (`aws-0-ca-central-1.pooler.supabase.com:5432`), which is IPv4 compatible

## Required Secrets (set in repo Settings → Secrets → Actions)

| Secret | Description |
|---|---|
| `SUPABASE_ACCESS_TOKEN` | Personal access token from supabase.com/dashboard/account/tokens |
| `OLD_DB_REF` | US East project ref (`cwhqffubvqolhnkecyck`) |
| `OLD_DB_PASSWORD` | US East DB password |
| `NEW_DB_REF` | Canada project ref |
| `NEW_DB_PASSWORD` | Canada DB password |

## Usage

Trigger manually from **Actions → Migrate Supabase US → Canada → Run workflow**. Delete the workflow file after migration is complete.