### PR TITLE
fix(ci): use supabase/setup-cli action instead of deprecated npm global install

### DIFF
--- a/.github/workflows/migrate-to-canada.yml
+++ b/.github/workflows/migrate-to-canada.yml
@@ -33,11 +33,15 @@ jobs:
       - name: Checkout repo (for migration SQL files)
         uses: actions/checkout@v6
 
-      - name: Install Supabase CLI + PostgreSQL client
+      - name: Install Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Install PostgreSQL client
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y postgresql-client
-          npm install -g supabase@latest
 
       - name: Dump public schema via Supabase CLI (HTTPS — no IPv6 issues)
         env:


### PR DESCRIPTION
## Problem

`npm install -g supabase@latest` now fails with:

```
npm error Installing Supabase CLI as a global module is not supported.
npm error Please use one of the supported package managers
```

## Fix

Replace the npm global install with the official [`supabase/setup-cli`](https://github.com/supabase/setup-cli) GitHub Action, which is the recommended installation method.