### PR TITLE
fix(ci): drop Supabase CLI, use pg_dump with us-east-2 pooler (IPv4)

### DIFF
--- a/.github/workflows/migrate-to-canada.yml
+++ b/.github/workflows/migrate-to-canada.yml
@@ -6,14 +6,14 @@
 # No Supabase CLI needed — avoids IPv6 direct DB connection issues in GitHub Actions.
 #
 # Required GitHub Secrets:
-#   OLD_DB_REF      = cwhqffubvqolhnkecyck  (just the project ref, no URL)
-#   OLD_DB_PASSWORD = old project DB password
-#   NEW_DB_REF      = your Canada project ref (e.g. abcdefghijklmnop)
-#   NEW_DB_PASSWORD = new Canada project DB password
+#   OLD_DB_REF          = cwhqffubvqolhnkecyck  (just the project ref, no URL)
+#   OLD_DB_PASSWORD     = old project DB password
+#   OLD_DB_POOLER_HOST  = find in: Supabase Dashboard → old project → Settings → Database → Connection Pooling
+#                         e.g. aws-0-us-east-2.pooler.supabase.com
+#   NEW_DB_REF          = your Canada project ref (e.g. abcdefghijklmnop)
+#   NEW_DB_PASSWORD     = new Canada project DB password
 #
-# Pooler hosts (hardcoded by region — no extra secrets needed):
-#   Old (US East):   aws-0-us-east-1.pooler.supabase.com
-#   New (CA Central): aws-0-ca-central-1.pooler.supabase.com
+# New Canada pooler host is hardcoded: aws-0-ca-central-1.pooler.supabase.com
 
 name: Migrate Supabase US → Canada
 
@@ -41,7 +41,7 @@ jobs:
       - name: Dump public schema via pooler (IPv4 — no IPv6 issues)
         env:
           PGPASSWORD: ${{ secrets.OLD_DB_PASSWORD }}
-          OLD_POOLER_URL: postgresql://postgres.${{ secrets.OLD_DB_REF }}:${{ secrets.OLD_DB_PASSWORD }}@aws-0-us-east-1.pooler.supabase.com:5432/postgres
+          OLD_POOLER_URL: postgresql://postgres.${{ secrets.OLD_DB_REF }}:${{ secrets.OLD_DB_PASSWORD }}@aws-0-us-east-2.pooler.supabase.com:5432/postgres
         run: |
           pg_dump "$OLD_POOLER_URL" \
             --schema public \
@@ -53,7 +53,7 @@ jobs:
       - name: Dump auth users via pooler (data only)
         env:
           PGPASSWORD: ${{ secrets.OLD_DB_PASSWORD }}
-          OLD_POOLER_URL: postgresql://postgres.${{ secrets.OLD_DB_REF }}:${{ secrets.OLD_DB_PASSWORD }}@aws-0-us-east-1.pooler.supabase.com:5432/postgres
+          OLD_POOLER_URL: postgresql://postgres.${{ secrets.OLD_DB_REF }}:${{ secrets.OLD_DB_PASSWORD }}@aws-0-us-east-2.pooler.supabase.com:5432/postgres
         run: |
           pg_dump "$OLD_POOLER_URL" \
             --schema auth \


### PR DESCRIPTION
Combines the last two fixes after PRs #308/#309 were closed without merging:

1. **Drop Supabase CLI** — use `pg_dump`/`psql` with pooler URLs only (no CLI dependencies)
2. **Correct old project region** — `us-east-1` → `us-east-2` (fixes "Tenant or user not found" error)

**To run after merging:** Actions → Migrate Supabase US → Canada → Run workflow → select `main`