### PR TITLE
fix(ci): add sslmode=require to all pooler connection URLs

### DIFF
--- a/.github/workflows/migrate-to-canada.yml
+++ b/.github/workflows/migrate-to-canada.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Dump public schema via pooler (IPv4 — no IPv6 issues)
         env:
           PGPASSWORD: ${{ secrets.OLD_DB_PASSWORD }}
-          OLD_POOLER_URL: postgresql://postgres.${{ secrets.OLD_DB_REF }}:${{ secrets.OLD_DB_PASSWORD }}@aws-0-us-east-2.pooler.supabase.com:5432/postgres
+          OLD_POOLER_URL: postgresql://postgres.${{ secrets.OLD_DB_REF }}:${{ secrets.OLD_DB_PASSWORD }}@aws-0-us-east-2.pooler.supabase.com:5432/postgres?sslmode=require
         run: |
           pg_dump "$OLD_POOLER_URL" \
             --schema public \
@@ -53,7 +53,7 @@ jobs:
       - name: Dump auth users via pooler (data only)
         env:
           PGPASSWORD: ${{ secrets.OLD_DB_PASSWORD }}
-          OLD_POOLER_URL: postgresql://postgres.${{ secrets.OLD_DB_REF }}:${{ secrets.OLD_DB_PASSWORD }}@aws-0-us-east-2.pooler.supabase.com:5432/postgres
+          OLD_POOLER_URL: postgresql://postgres.${{ secrets.OLD_DB_REF }}:${{ secrets.OLD_DB_PASSWORD }}@aws-0-us-east-2.pooler.supabase.com:5432/postgres?sslmode=require
         run: |
           pg_dump "$OLD_POOLER_URL" \
             --schema auth \
@@ -66,7 +66,7 @@ jobs:
       - name: Restore public schema to Canada project (via pooler — IPv4)
         env:
           PGPASSWORD: ${{ secrets.NEW_DB_PASSWORD }}
-          NEW_POOLER_URL: postgresql://postgres.${{ secrets.NEW_DB_REF }}:${{ secrets.NEW_DB_PASSWORD }}@aws-0-ca-central-1.pooler.supabase.com:5432/postgres
+          NEW_POOLER_URL: postgresql://postgres.${{ secrets.NEW_DB_REF }}:${{ secrets.NEW_DB_PASSWORD }}@aws-0-ca-central-1.pooler.supabase.com:5432/postgres?sslmode=require
         run: |
           psql "$NEW_POOLER_URL" --file=haccare_public.sql
           echo "Public schema restore complete"
@@ -74,7 +74,7 @@ jobs:
       - name: Restore auth users to Canada project
         env:
           PGPASSWORD: ${{ secrets.NEW_DB_PASSWORD }}
-          NEW_POOLER_URL: postgresql://postgres.${{ secrets.NEW_DB_REF }}:${{ secrets.NEW_DB_PASSWORD }}@aws-0-ca-central-1.pooler.supabase.com:5432/postgres
+          NEW_POOLER_URL: postgresql://postgres.${{ secrets.NEW_DB_REF }}:${{ secrets.NEW_DB_PASSWORD }}@aws-0-ca-central-1.pooler.supabase.com:5432/postgres?sslmode=require
         run: |
           psql "$NEW_POOLER_URL" -c "TRUNCATE auth.identities CASCADE; TRUNCATE auth.users CASCADE;"
           psql "$NEW_POOLER_URL" --file=haccare_auth.sql
@@ -83,7 +83,7 @@ jobs:
       - name: Apply RLS event trigger migration
         env:
           PGPASSWORD: ${{ secrets.NEW_DB_PASSWORD }}
-          NEW_POOLER_URL: postgresql://postgres.${{ secrets.NEW_DB_REF }}:${{ secrets.NEW_DB_PASSWORD }}@aws-0-ca-central-1.pooler.supabase.com:5432/postgres
+          NEW_POOLER_URL: postgresql://postgres.${{ secrets.NEW_DB_REF }}:${{ secrets.NEW_DB_PASSWORD }}@aws-0-ca-central-1.pooler.supabase.com:5432/postgres?sslmode=require
         run: |
           psql "$NEW_POOLER_URL" \
             --file=database/migrations/20260507000000_enable_automatic_rls_event_trigger.sql
@@ -92,7 +92,7 @@ jobs:
       - name: Verify row counts
         env:
           PGPASSWORD: ${{ secrets.NEW_DB_PASSWORD }}
-          NEW_POOLER_URL: postgresql://postgres.${{ secrets.NEW_DB_REF }}:${{ secrets.NEW_DB_PASSWORD }}@aws-0-ca-central-1.pooler.supabase.com:5432/postgres
+          NEW_POOLER_URL: postgresql://postgres.${{ secrets.NEW_DB_REF }}:${{ secrets.NEW_DB_PASSWORD }}@aws-0-ca-central-1.pooler.supabase.com:5432/postgres?sslmode=require
         run: |
           psql "$NEW_POOLER_URL" <<'SQL'
             SELECT table_name,
@@ -106,6 +106,6 @@ jobs:
       - name: Verify auth users migrated
         env:
           PGPASSWORD: ${{ secrets.NEW_DB_PASSWORD }}
-          NEW_POOLER_URL: postgresql://postgres.${{ secrets.NEW_DB_REF }}:${{ secrets.NEW_DB_PASSWORD }}@aws-0-ca-central-1.pooler.supabase.com:5432/postgres
+          NEW_POOLER_URL: postgresql://postgres.${{ secrets.NEW_DB_REF }}:${{ secrets.NEW_DB_PASSWORD }}@aws-0-ca-central-1.pooler.supabase.com:5432/postgres?sslmode=require
         run: |
           psql "$NEW_POOLER_URL" -c "SELECT COUNT(*) AS user_count FROM auth.users;"


### PR DESCRIPTION
Fixes `FATAL: (ESSLREQUIRED) SSL connection is required` error on all `pg_dump`/`psql` pooler connections.