### PR TITLE
fix(ci): restore auth before public to fix FK violations on user_profiles

### DIFF
--- a/.github/workflows/migrate-to-canada.yml
+++ b/.github/workflows/migrate-to-canada.yml
@@ -69,15 +69,7 @@ jobs:
             --file haccare_auth.sql
           echo "Auth dump size: $(du -sh haccare_auth.sql | cut -f1)"
 
-      - name: Restore public schema to Canada project (via pooler — IPv4)
-        env:
-          PGPASSWORD: ${{ secrets.NEW_DB_PASSWORD }}
-          NEW_POOLER_URL: postgresql://postgres.${{ secrets.NEW_DB_REF }}:${{ secrets.NEW_DB_PASSWORD }}@aws-1-ca-central-1.pooler.supabase.com:5432/postgres?sslmode=require
-        run: |
-          psql "$NEW_POOLER_URL" --file=haccare_public.sql
-          echo "Public schema restore complete"
-
-      - name: Restore auth users to Canada project
+      - name: Restore auth users FIRST (must exist before public FK references)
         env:
           PGPASSWORD: ${{ secrets.NEW_DB_PASSWORD }}
           NEW_POOLER_URL: postgresql://postgres.${{ secrets.NEW_DB_REF }}:${{ secrets.NEW_DB_PASSWORD }}@aws-1-ca-central-1.pooler.supabase.com:5432/postgres?sslmode=require
@@ -85,6 +77,14 @@ jobs:
           psql "$NEW_POOLER_URL" -c "TRUNCATE auth.identities CASCADE; TRUNCATE auth.users CASCADE;"
           psql "$NEW_POOLER_URL" --file=haccare_auth.sql
           echo "Auth user restore complete"
+
+      - name: Restore public schema to Canada project (via pooler — IPv4)
+        env:
+          PGPASSWORD: ${{ secrets.NEW_DB_PASSWORD }}
+          NEW_POOLER_URL: postgresql://postgres.${{ secrets.NEW_DB_REF }}:${{ secrets.NEW_DB_PASSWORD }}@aws-1-ca-central-1.pooler.supabase.com:5432/postgres?sslmode=require
+        run: |
+          psql "$NEW_POOLER_URL" --file=haccare_public.sql
+          echo "Public schema restore complete"
 
       - name: Apply RLS event trigger migration
         env:


### PR DESCRIPTION
Fixes empty `user_profiles` table after migration. The root cause was FK ordering — `user_profiles` references `auth.users`, but auth was being restored *after* public, causing all `user_profiles` inserts to fail silently with FK violations.\n\nFix: restore auth first, then public.