### PR TITLE
fix(ci): truncate all public tables before restore to prevent PK/FK conflicts

### DIFF
--- a/.github/workflows/migrate-to-canada.yml
+++ b/.github/workflows/migrate-to-canada.yml
@@ -78,6 +78,22 @@ jobs:
           psql "$NEW_POOLER_URL" --file=haccare_auth.sql
           echo "Auth user restore complete"
 
+      - name: Truncate all public tables (clean slate before restore)
+        env:
+          PGPASSWORD: ${{ secrets.NEW_DB_PASSWORD }}
+          NEW_POOLER_URL: postgresql://postgres.${{ secrets.NEW_DB_REF }}:${{ secrets.NEW_DB_PASSWORD }}@aws-1-ca-central-1.pooler.supabase.com:5432/postgres?sslmode=require
+        run: |
+          psql "$NEW_POOLER_URL" <<'SQL'
+            DO $$
+            DECLARE r RECORD;
+            BEGIN
+              FOR r IN SELECT tablename FROM pg_tables WHERE schemaname = 'public' LOOP
+                EXECUTE 'TRUNCATE TABLE public.' || quote_ident(r.tablename) || ' CASCADE';
+              END LOOP;
+            END $$;
+          SQL
+          echo "Public tables truncated"
+
       - name: Restore public schema to Canada project (via pooler — IPv4)
         env:
           PGPASSWORD: ${{ secrets.NEW_DB_PASSWORD }}


### PR DESCRIPTION
Fixes missing simulations, tenants, and all other public data after migration.\n\nRoot cause: the new Supabase project's tables are not empty — they contain rows from initial setup. Our `COPY` statements conflict on primary keys, so PostgreSQL skips them silently.\n\nFix: add a step that truncates all public tables (with `CASCADE`) before restoring, giving a clean slate for the data load.